### PR TITLE
v1.5.4

### DIFF
--- a/com.github.PopoutApps.popout3d.yml
+++ b/com.github.PopoutApps.popout3d.yml
@@ -191,4 +191,3 @@ modules:
     - type: git
       tag: main
       url: https://github.com/PopoutApps/popout3d
-


### PR DESCRIPTION
Process in background.
Keep list of new images to review.
Remove some align-image-stack parameters to avoid hangs.
Bugfixes.